### PR TITLE
Add Docker support and CI workflow for building Docker images

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,6 @@
+.git
+.gitignore
+__pycache__
+tests
+*.pyc
+.env

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,13 @@
+FROM python:3.11-slim
+
+WORKDIR /app
+
+RUN pip install uv
+
+COPY . .
+
+RUN uv sync
+
+EXPOSE 8463
+
+CMD ["uv", "run", "fakevine"]


### PR DESCRIPTION
This PR adds initial Docker support for running FakeVine.

Changes:
- Added Dockerfile to containerize the FastAPI application
- Added .dockerignore to reduce image size
- Added GitHub Actions workflow to build the Docker image on push and pull requests

The container runs the application using `uv run fakevine` and exposes port 8463.

Example usage:

docker build -t fakevine .
docker run -p 8463:8463 -e CACHE_CV_API_KEY=your_api_key fakevine

This implements the "Docker image" feature mentioned in the README.

Closes #9